### PR TITLE
Documentation fix for nuget package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ dotnet new web
 ```shell
 dotnet add package serilog.aspnetcore
 dotnet add package serilog.sinks.seq
-dotnet add package serilog.filters.expressions
+dotnet add package serilog.expressions
 ```
 
 ### 3. Initialize Serilog at the start of `Program.cs`


### PR DESCRIPTION
Fix documentation to point to the correct package "serilog.expressions" nuget package.

It appears the package "serilog.filters.expressions" is deprecated.  The actual project file is using the correct "serilog.expressions" package, so this is documentation only.

https://github.com/serilog/serilog-filters-expressions
https://github.com/serilog/serilog-expressions